### PR TITLE
Test report not uploaded if a test fails

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,4 +31,5 @@ jobs:
         run: pytest -v --tb=short --disable-warnings --emoji --md report.md
 
       - name: Add test report to job summary
+        if: always()
         run: cat report.md >> $GITHUB_STEP_SUMMARY

--- a/app/main.py
+++ b/app/main.py
@@ -29,7 +29,7 @@ def get_root():
 
     :return: A dictionary with a message key.
     """
-    return {"message": "Hello, World!"}
+    return {"message": "Goodbye, World!"}
 
 
 @app.get("/todos")

--- a/app/main.py
+++ b/app/main.py
@@ -29,7 +29,7 @@ def get_root():
 
     :return: A dictionary with a message key.
     """
-    return {"message": "Goodbye, World!"}
+    return {"message": "Hello, World!"}
 
 
 @app.get("/todos")


### PR DESCRIPTION
Since GitHub Actions only runs a step if the previous one passed (by default), the last step that uploads the test summary as an artifact needs to always run. We can do this by adding `if: always()` to the step.